### PR TITLE
fixing react cross origin errors

### DIFF
--- a/examples/react/webpack.config.js
+++ b/examples/react/webpack.config.js
@@ -3,6 +3,7 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const meteorExternals = require('webpack-meteor-externals');
 
 const clientConfig = {
+  devtool: 'cheap-module-source-map',
   entry: './client/main.jsx',
   module: {
     rules: [{


### PR DESCRIPTION
When I had exceptions I was getting this error from React https://reactjs.org/docs/cross-origin-errors.html#source-maps

Now it's fixed.