### PR TITLE
Fix webpack bundle executing before Meteor packages/runtime config

### DIFF
--- a/atmosphere-packages/webpack-dev-middleware/dev-server.js
+++ b/atmosphere-packages/webpack-dev-middleware/dev-server.js
@@ -235,7 +235,7 @@ if (Meteor.isServer && Meteor.isDevelopment) {
             const index = clientConfig.devServer.index || 'index.html'
 
             if (index in assets) {
-                const content = assets[index].source().split(' src="').join(' defer async src="');
+                const content = assets[index].source().split(' src="').join(' defer src="');
 
                 WebAppInternals.registerBoilerplateDataCallback('meteor/ardatan:webpack', (req, data) => {
                     const head = HEAD_REGEX.exec(content)[1];


### PR DESCRIPTION
Hey @ardatan, great package!

This fixes an issue in development where the webpack bundle can execute before the Meteor packages and runtime config have loaded. Looks like you fixed this back in #18 , but somewhere the `async` tag crept back in. In order to execute the webpack bundle after Meteor's packages and runtime config, the `defer` tag without `async` is required. 

As a reference on defer vs async: https://www.w3schools.com/tags/att_script_defer.asp

```
If async is present: The script is executed asynchronously with the rest of the page (the script will be executed while the page continues the parsing)
If async is not present and defer is present: The script is executed when the page has finished parsing
If neither async or defer is present: The script is fetched and executed immediately, before the browser continues parsing the page
```