### PR TITLE
Avoid running webpack-dev-middleware in test mode

### DIFF
--- a/atmosphere-packages/webpack-dev-middleware/dev-server.js
+++ b/atmosphere-packages/webpack-dev-middleware/dev-server.js
@@ -204,7 +204,7 @@ function arrangeConfig(webpackConfig) {
     return webpackConfig;
 }
 
-if (Meteor.isServer && Meteor.isDevelopment) {
+if (Meteor.isServer && Meteor.isDevelopment && !Meteor.isTest && !Meteor.isAppTest) {
     const webpack = Npm.require(path.join(projectPath, 'node_modules/webpack'))
     const webpackConfig = arrangeConfig(Npm.require(path.join(projectPath, WEBPACK_CONFIG_FILE)));
 


### PR DESCRIPTION
This PR avoids running `webpack-dev-middleware` during `meteor test`.

A problem still remains for tests in watch mode. The server will not restart if a change is made, due to the presence of `.meteorignore`. A possible solution is to rename `.meteorignore` before running any tests in watch mode.

I explored a few different options to make this work, including running webpack-dev-middleware anyway, by setting `--test-app-path` to an absolute path to a directory directly inside the project's root (e.g. `--test-app-path /path/to/project/.meteortest`). This allows `webpack-dev-middleware` to find the `webpack` npm and `webpack.config.js` and allows HMR to work in test mode, however I don't think it would be compatible with any test runners since they won't be able to wait until the HMR is complete before running their tests.

This should fix #38 