### PR TITLE
Convert peer dependencies to direct dependencies 

### DIFF
--- a/atmosphere-packages/webpack-dev-middleware/.npm/package/.gitignore
+++ b/atmosphere-packages/webpack-dev-middleware/.npm/package/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/atmosphere-packages/webpack-dev-middleware/.npm/package/README
+++ b/atmosphere-packages/webpack-dev-middleware/.npm/package/README
@@ -1,0 +1,7 @@
+This directory and the files immediately inside it are automatically generated
+when you change this package's NPM dependencies. Commit the files in this
+directory (npm-shrinkwrap.json, .gitignore, and this README) to source control
+so that others run the same versions of sub-dependencies.
+
+You should NOT check in the node_modules directory that Meteor automatically
+creates; if you are using git, the .gitignore file tells git to ignore it.

--- a/atmosphere-packages/webpack-dev-middleware/.npm/package/npm-shrinkwrap.json
+++ b/atmosphere-packages/webpack-dev-middleware/.npm/package/npm-shrinkwrap.json
@@ -1,0 +1,35 @@
+{
+  "lockfileVersion": 1,
+  "dependencies": {
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+    },
+    "debug": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw=="
+    },
+    "ms": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+    },
+    "require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
+    },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+    },
+    "source-map-support": {
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz",
+      "integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA=="
+    }
+  }
+}

--- a/atmosphere-packages/webpack-dev-middleware/dev-server.js
+++ b/atmosphere-packages/webpack-dev-middleware/dev-server.js
@@ -34,7 +34,7 @@ function getFilename(serverStats, outputPath, chunkName) {
 }
 
 function installSourceMapSupport(fs) {
-    const sourceMapSupport = Npm.require(path.join(projectPath, 'node_modules/source-map-support'));
+    const sourceMapSupport = Npm.require('source-map-support');
     sourceMapSupport.install({
         // NOTE: If https://github.com/evanw/node-source-map-support/pull/149
         // lands we can be less aggressive and explicitly invalidate the source
@@ -152,7 +152,7 @@ function webpackHotServerMiddleware(multiCompiler) {
         }
 
         try {
-            const requireFromString = Npm.require(path.join(projectPath, 'node_modules/require-from-string'));
+            const requireFromString = Npm.require('require-from-string');
             interopRequireDefault(
                 requireFromString(buffer.toString(), filename)
             );

--- a/atmosphere-packages/webpack-dev-middleware/package.js
+++ b/atmosphere-packages/webpack-dev-middleware/package.js
@@ -11,3 +11,9 @@ Package.onUse(function (api) {
     api.use('webapp@1.5.0', 'server');
     api.addFiles('dev-server.js', 'server');
 });
+
+Npm.depends({
+    debug: "4.1.1",
+    "source-map-support": "0.5.9",
+    "require-from-string": "2.0.2"
+});


### PR DESCRIPTION
I kept getting errors that the node modules used by the webpack-dev-server were not in my project. Specifically `debug`, `require-from-string` and `source-map-support`. This PR adds them as direct dependencies rather than peer dependencies.

If this is not desirable, perhaps it would be useful to update the readme to notify new users that they will need to install these peer dependencies manually.