### PR TITLE
Add server-render package compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,10 @@ don't forget to install `webpack-dev-middleware` package from NPM;
     !webpack.config.js
 ```
 
+### meteor/server-render
+
+- Meteor's `server-render` will work as expected if you use webpack to include HTML via `HtmlWebpackPlugin`. **Important: Be sure that server-render is listed BELOW webpack-dev-server in `meteor/packages`**
+
 ## Galaxy Deployment
 `meteor deploy` command doesn't set `NODE_ENV=production` environment variable. That's why, `webpack` compiler recognizes that it is still a `development` build. You have two options to fix issue;
 ### First option ( Recommended )

--- a/atmosphere-packages/webpack-dev-middleware/dev-server.js
+++ b/atmosphere-packages/webpack-dev-middleware/dev-server.js
@@ -272,6 +272,9 @@ if (Meteor.isServer && Meteor.isDevelopment && !Meteor.isTest && !Meteor.isAppTe
                 head = HEAD_REGEX.exec(content)[1];
                 body = BODY_REGEX.exec(content)[1];
             }
+
+            // Remove any whitespace at the end of the body or server-render will mangle the HTML output
+            body = body.replace(/[\t\n\r\s]+$/, '')
         });
         
         if (clientConfig && clientConfig.devServer && clientConfig.devServer.hot) {


### PR DESCRIPTION
This PR adds compatibility with Meteor's `server-render` package for HTML included via `HtmlWebpackPlugin`. An important note is that `server-render` must be listed below `ardatan:webpack-dev-server` in `.meteor/packages` for the correct boilerplate callback order to be registered.

Previously, this repo did not work with `server-render` because the dev server boilerplate callback executes after `server-render`'s.