### PR TITLE
Add support for dynamic JS and CSS assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,10 @@ don't forget to install `webpack-dev-middleware` package from NPM;
     !webpack.config.js
 ```
 
+### Dynamic boilerplate assets
+
+- You can use `WebAppInternals.registerBoilerplateCallback` to dynamically change the CSS and JS served to visitors via `data.js` and `data.css`. In order to use this feature with webpack, you must set `inject: false` on `HtmlWebpackPlugin` and set the environment variable `DYNAMIC_ASSETS=true`.
+
 ## Galaxy Deployment
 `meteor deploy` command doesn't set `NODE_ENV=production` environment variable. That's why, `webpack` compiler recognizes that it is still a `development` build. You have two options to fix issue;
 ### First option ( Recommended )


### PR DESCRIPTION
This PR depends on and includes #55. This adds support for dynamically changing JS and CSS assets in the boilerplate at runtime. Some applications may wish to serve different assets to different requests. This is done like so:

```js
WebAppInternals.registerBoilerplateDataCallback('your-hook', (req, data) => {
  // re-assign data.js and data.css arrays here, do NOT mutate them
  data.js = data.js.filter( ... )
})
```