### PR TITLE
Add support for tests and watch mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,3 +179,10 @@ or
 ## Second option
 - Create a seperate configuration file for `webpack` which doesn't contain development settings such as `devServer`, and includes `UglifyJs` plugins. Then, set environment variable `WEBPACK_CONFIG_FILE=<filename>`.
 
+## Testing
+
+- Using `meteor test` requires the option  `--test-app-path $(pwd)/.meteortest`. This will run the test inside the `.meteortest` directory in your project. Normally, `meteor test` runs a test version of the application inside your `/tmp` directory, but webpack needs to be able to access the project's `node_modules` folder.
+
+- You may also run into permissions issues after the `.meteortest` folder is created. I recommend adding `rm -r .meteortest` to the beginning of your test command.
+
+- All DDP connections are closed when the dev server recompiles in test mode. This will trigger testing libraries that use DDP (Chimpy) to re-run if they are in watch mode.

--- a/atmosphere-packages/webpack-dev-middleware/dev-server.js
+++ b/atmosphere-packages/webpack-dev-middleware/dev-server.js
@@ -227,7 +227,7 @@ function arrangeConfig(webpackConfig) {
     return webpackConfig;
 }
 
-if (Meteor.isServer && Meteor.isDevelopment && !Meteor.isTest && !Meteor.isAppTest) {
+if (Meteor.isServer && Meteor.isDevelopment) {
     const webpack = Npm.require(path.join(projectPath, 'node_modules/webpack'))
     const webpackConfig = arrangeConfig(Npm.require(path.join(projectPath, WEBPACK_CONFIG_FILE)));
 
@@ -267,6 +267,13 @@ if (Meteor.isServer && Meteor.isDevelopment && !Meteor.isTest && !Meteor.isAppTe
                     const body = BODY_REGEX.exec(content)[1];
                     data.dynamicBody = data.dynamicBody || '';
                     data.dynamicBody += body;
+                })
+            }
+
+            // Close all websockets so test runners monitoring the DDP connection (like Chimpy) know when to re-run
+            if (Meteor.isTest || Meteor.isAppTest) {
+                Meteor.server.stream_server.open_sockets.forEach(function(socket) {
+                    socket.close()
                 })
             }
         });


### PR DESCRIPTION
This PR adds support for `meteor test`. One thing to note is that the option `--test-app-path` must be specified to a directory within the main project root. Webpack needs to be able to access `node_modules` that are installed with the project and are not copied into the temporary test directory. I've updated the readme accordingly.

Closing websockets after compilation allows Chimpy to re-run when in watch mode (it monitors a DDP connection to know when the server restarts).