### PR TITLE
Initial server cleaning functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ then you have to add another atmosphere package to packages;
     meteor add ardatan:webpack-dev-middleware
 ```
 
+***NOTE*** Make sure `ardatan:webpack-dev-middleware` is at the bottom of your `.packages` list for the best compatibility with other Meteor packages.
+
 don't forget to install `webpack-dev-middleware` package from NPM;
 
 ```bash

--- a/atmosphere-packages/webpack-dev-middleware/dev-server.js
+++ b/atmosphere-packages/webpack-dev-middleware/dev-server.js
@@ -237,7 +237,7 @@ if (Meteor.isServer && Meteor.isDevelopment) {
     let validateNewUserHooks = []
     let _validateLoginHookCallbacks
     let accountsOptions = {}
-    let nullPublications = Meteor.server.universal_publish_handlers
+    let nullPublications = Array.from(Meteor.server.universal_publish_handlers)
 
     if(Package['accounts-base']) {
         const { Accounts } = Package['accounts-base']
@@ -287,7 +287,7 @@ if (Meteor.isServer && Meteor.isDevelopment) {
       
         WebApp.rawConnectHandlers.use(webpackDevMiddleware(compiler, {
             index: false,
-            ...clientConfig.devServer
+            ...clientConfig.devServer,
         }));
 
         let head

--- a/atmosphere-packages/webpack-dev-middleware/dev-server.js
+++ b/atmosphere-packages/webpack-dev-middleware/dev-server.js
@@ -235,6 +235,7 @@ if (Meteor.isServer && Meteor.isDevelopment) {
     let connectHandlers = Array.from(WebApp.connectHandlers.stack)
     let loginHandlers = []
     let validateNewUserHooks = []
+    let _validateLoginHookCallbacks
     let accountsOptions = {}
 
     if(Package['accounts-base']) {
@@ -242,7 +243,9 @@ if (Meteor.isServer && Meteor.isDevelopment) {
         accountsOptions = Object.assign({}, Accounts._options)
         loginHandlers = Array.from(Accounts._loginHandlers)
         validateNewUserHooks = Array.from(Accounts._validateNewUserHooks)
+        _validateLoginHookCallbacks = Object.assign({}, Accounts._validateLoginHook.callbacks)
     }
+
 
     // Restore the state of the Meteor server ahead of hot module replacement
     function cleanServer() {
@@ -259,7 +262,8 @@ if (Meteor.isServer && Meteor.isDevelopment) {
             const { Accounts } = Package['accounts-base']
             Accounts.__loginHandlers = loginHandlers
             Accounts._validateNewUserHooks = validateNewUserHooks
-            Accounts._options = {}
+            Accounts._options = Object.assign({}, accountsOptions)
+            Accounts._validateLoginHook.callbacks = Object.assign({}, _validateLoginHookCallbacks)
         }
     }
 

--- a/atmosphere-packages/webpack-dev-middleware/dev-server.js
+++ b/atmosphere-packages/webpack-dev-middleware/dev-server.js
@@ -230,44 +230,6 @@ function arrangeConfig(webpackConfig) {
 
 if (Meteor.isServer && Meteor.isDevelopment) {
 
-    // Cache the initial state of the Meteor server before the application code is executed
-    let rawConnectHandlers = Array.from(WebApp.rawConnectHandlers.stack)
-    let connectHandlers = Array.from(WebApp.connectHandlers.stack)
-    let loginHandlers = []
-    let validateNewUserHooks = []
-    let _validateLoginHookCallbacks
-    let accountsOptions = {}
-    let nullPublications = Array.from(Meteor.server.universal_publish_handlers)
-
-    if(Package['accounts-base']) {
-        const { Accounts } = Package['accounts-base']
-        accountsOptions = Object.assign({}, Accounts._options)
-        loginHandlers = Array.from(Accounts._loginHandlers)
-        validateNewUserHooks = Array.from(Accounts._validateNewUserHooks)
-        _validateLoginHookCallbacks = Object.assign({}, Accounts._validateLoginHook.callbacks)
-    }
-
-    // Restore the state of the Meteor server ahead of hot module replacement
-    function cleanServer() {
-        WebApp.rawConnectHandlers.stack = rawConnectHandlers
-        WebApp.connectHandlers.stack = connectHandlers
-        Meteor.server.universal_publish_handlers = nullPublications
-        if(Package['server-render']) {
-            Package['server-render'].onPageLoad.clear()
-        }
-        if(Package['staringatlights:fast-render']) {
-            const FastRender = Package['staringatlights:fast-render'].FastRender
-            FastRender._onAllRoutes = [FastRender._onAllRoutes[0]]
-        }
-        if(Package['accounts-base']) {
-            const { Accounts } = Package['accounts-base']
-            Accounts._loginHandlers = loginHandlers
-            Accounts._validateNewUserHooks = validateNewUserHooks
-            Accounts._options = Object.assign({}, accountsOptions)
-            Accounts._validateLoginHook.callbacks = Object.assign({}, _validateLoginHookCallbacks)
-        }
-    }
-
     const webpack = Npm.require(path.join(projectPath, 'node_modules/webpack'))
     const webpackConfig = arrangeConfig(Npm.require(path.join(projectPath, WEBPACK_CONFIG_FILE)));
 
@@ -305,6 +267,44 @@ if (Meteor.isServer && Meteor.isDevelopment) {
                 data.css = data.css.concat(css)
             }
         })
+
+        // Cache the initial state of the Meteor server before the application code is executed
+        let rawConnectHandlers = Array.from(WebApp.rawConnectHandlers.stack)
+        let connectHandlers = Array.from(WebApp.connectHandlers.stack)
+        let loginHandlers = []
+        let validateNewUserHooks = []
+        let _validateLoginHookCallbacks
+        let accountsOptions = {}
+        let nullPublications = Array.from(Meteor.server.universal_publish_handlers)
+
+        if(Package['accounts-base']) {
+            const { Accounts } = Package['accounts-base']
+            accountsOptions = Object.assign({}, Accounts._options)
+            loginHandlers = Array.from(Accounts._loginHandlers)
+            validateNewUserHooks = Array.from(Accounts._validateNewUserHooks)
+            _validateLoginHookCallbacks = Object.assign({}, Accounts._validateLoginHook.callbacks)
+        }
+
+        // Restore the state of the Meteor server ahead of hot module replacement
+        function cleanServer() {
+            WebApp.rawConnectHandlers.stack = rawConnectHandlers
+            WebApp.connectHandlers.stack = connectHandlers
+            Meteor.server.universal_publish_handlers = nullPublications
+            if(Package['server-render']) {
+                Package['server-render'].onPageLoad.clear()
+            }
+            if(Package['staringatlights:fast-render']) {
+                const FastRender = Package['staringatlights:fast-render'].FastRender
+                FastRender._onAllRoutes = [FastRender._onAllRoutes[0]]
+            }
+            if(Package['accounts-base']) {
+                const { Accounts } = Package['accounts-base']
+                Accounts._loginHandlers = loginHandlers
+                Accounts._validateNewUserHooks = validateNewUserHooks
+                Accounts._options = Object.assign({}, accountsOptions)
+                Accounts._validateLoginHook.callbacks = Object.assign({}, _validateLoginHookCallbacks)
+            }
+        }
 
         compiler.hooks.done.tap('meteor-webpack', ({
             stats

--- a/atmosphere-packages/webpack-dev-middleware/dev-server.js
+++ b/atmosphere-packages/webpack-dev-middleware/dev-server.js
@@ -237,6 +237,7 @@ if (Meteor.isServer && Meteor.isDevelopment) {
     let validateNewUserHooks = []
     let _validateLoginHookCallbacks
     let accountsOptions = {}
+    let nullPublications = Meteor.server.universal_publish_handlers
 
     if(Package['accounts-base']) {
         const { Accounts } = Package['accounts-base']
@@ -246,11 +247,11 @@ if (Meteor.isServer && Meteor.isDevelopment) {
         _validateLoginHookCallbacks = Object.assign({}, Accounts._validateLoginHook.callbacks)
     }
 
-
     // Restore the state of the Meteor server ahead of hot module replacement
     function cleanServer() {
         WebApp.rawConnectHandlers.stack = rawConnectHandlers
         WebApp.connectHandlers.stack = connectHandlers
+        Meteor.server.universal_publish_handlers = nullPublications
         if(Package['server-render']) {
             Package['server-render'].onPageLoad.clear()
         }

--- a/atmosphere-packages/webpack-dev-middleware/dev-server.js
+++ b/atmosphere-packages/webpack-dev-middleware/dev-server.js
@@ -260,7 +260,7 @@ if (Meteor.isServer && Meteor.isDevelopment) {
         }
         if(Package['accounts-base']) {
             const { Accounts } = Package['accounts-base']
-            Accounts.__loginHandlers = loginHandlers
+            Accounts._loginHandlers = loginHandlers
             Accounts._validateNewUserHooks = validateNewUserHooks
             Accounts._options = Object.assign({}, accountsOptions)
             Accounts._validateLoginHook.callbacks = Object.assign({}, _validateLoginHookCallbacks)


### PR DESCRIPTION
This PR adds some caching and purging of handlers to essentially "reset" initial state of the server and make it HMR-friendly. For maximum compatibility, I recommend making sure the webpack packages are at the bottom of the `.packages` list, so that any handlers added by third party packages are not purged. The only exception to this would be the `server-render` package which needs to be at the bottom.

Fixes #15 