### PR TITLE
Add webpack.config.js with path aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,6 @@ With Meteor-Webpack, you can extract `webpack.config.js` from Angular CLI, `crea
 - If you have an existing meteor app and do not want to change the pathnames from '/imports/...' to relative paths, use the following in your `webpack.config.js`
 
 ```js
-    const meteorExternals = require('webpack-meteor-externals');
     //...
     resolve: {
         modules: [

--- a/README.md
+++ b/README.md
@@ -101,6 +101,26 @@ With Meteor-Webpack, you can extract `webpack.config.js` from Angular CLI, `crea
     //...
 ```
 
+## Meteor File Imports - Optional
+- If you have an existing meteor app and do not want to change the pathnames from '/imports/...' to relative paths, use the following in your `webpack.config.js`
+
+```js
+    const meteorExternals = require('webpack-meteor-externals');
+    //...
+    resolve: {
+        modules: [
+          path.resolve(__dirname, 'node_modules'),
+          path.resolve(__dirname, './'), // enables you to use 'imports/...' instead of '/imports/...'
+        ],
+        alias: {
+          '/imports': path.resolve(__dirname, './imports'),
+          '/ui': path.resolve(__dirname, './ui'),
+          // ... and any other directories you might have
+        }
+    }
+    //...
+```
+
 ### Client Configuration
 
 #### [Webpack Dev Middleware](https://github.com/webpack/webpack-dev-middleware)


### PR DESCRIPTION
Add webpack.config.js example to allow keeping the pathnames unchanged in an existing meteor app